### PR TITLE
COMPSCI 2050 Spring 2026 setup

### DIFF
--- a/local/cs2050-cpu.yml.erb
+++ b/local/cs2050-cpu.yml.erb
@@ -1,0 +1,86 @@
+# Code Server app user-facing configuration form file (generic sub-app)
+# This config file is both an actual configuration file for an actual sample 
+# application, and a starting point for configuring a new sub-app. To make a 
+# custom application launch for a course, make a copy of this file in the same
+# folder and customize the form config to your liking. There are notes along
+# the way to help you understand what options you can make configurable to users.
+# See the docs page from Open OnDemand for more details:
+# https://osc.github.io/ood-documentation/develop/how-tos/app-development/interactive/form.html
+<%-
+# Specify admin groups by the full name of the group in the production HKey environment.
+adminGroups = [
+  "ondemand-admins-1025174" # HUIT OOD admin group, prod environment
+]
+# Specify course groups by Canvas course ID, which you can find in a url:
+# canvas.harvard.edu/courses/000000
+enabledGroups = [
+  # Cannot have multiple enabled groups if a spack installation in the course 
+  # shared folder is in use. This is because the course installation uses the 
+  # course shared folder, which is not accessible to users outside of that 
+  # course.
+  "161588"
+]
+
+def arrays_have_common_element(array1, array2)
+  # Use the `&` operator to get the intersection of the two arrays
+  # If the intersection is not empty, return true, otherwise false
+  !(array1 & array2).empty?
+end
+
+userGroups = OodSupport::User.new.groups.sort_by(&:id).map(&:name)
+# First check if the user is in an admin group
+if arrays_have_common_element(userGroups, adminGroups)
+  cluster="*"
+else
+  # If the user is not in an admin group, check if they're in an authorized Canvas group
+  userCanvasGroups = userGroups.flat_map{ |str| str.scan(/^canvas(\d+)-\d+/) }.flatten
+
+  # Check if the groups that the user is in match any of the courses that should
+  # have access to this app.
+
+  if arrays_have_common_element(userCanvasGroups, enabledGroups)
+    cluster="*"
+  else
+    cluster="disable_this_app"
+  end
+end
+-%>
+---
+title: Code Server - COMPSCI 2050 (CPU)
+cluster: "<%= cluster %>"
+cacheable: false
+
+# Form attributes that will be presented to the user and available to the 
+# scripts that launch the app. Think of this as initializing variables for use 
+# in the attributes section as needed.
+form:
+  - bc_num_hours
+  - bc_queue
+  - custom_num_cores
+  - custom_spack_install
+  - custom_spack_environment
+
+# Customize how form variables appear to users. This is also where you can set 
+# a static value for a variable, in which case it will not be visible to users.
+attributes:
+  # How long will the job run for? Configure min, max, and step to set limits 
+  # on how long app sessions can run.
+  bc_num_hours:
+    value: 2
+    min: 1
+    max: 6  # 6 hours max
+    step: 1
+
+  # Which queue to submit to. Usually `general` is the best choice, unless this 
+  # app is configured for a specific EC2 instance type, like an instance type 
+  # with GPU resources.
+  bc_queue: "general"
+  custom_num_cores:
+    widget: "number_field"
+    label: "Number of CPUs"
+    value: 1
+    min: 1
+    max: 48
+    step: 1
+  custom_spack_install: "/shared/courseSharedFolders/161588outer/161588/spack"
+  custom_spack_environment: "cs2050-cpu"

--- a/local/cs2050-gpu.yml.erb
+++ b/local/cs2050-gpu.yml.erb
@@ -1,0 +1,87 @@
+# Code Server app user-facing configuration form file (generic sub-app)
+# This config file is both an actual configuration file for an actual sample 
+# application, and a starting point for configuring a new sub-app. To make a 
+# custom application launch for a course, make a copy of this file in the same
+# folder and customize the form config to your liking. There are notes along
+# the way to help you understand what options you can make configurable to users.
+# See the docs page from Open OnDemand for more details:
+# https://osc.github.io/ood-documentation/develop/how-tos/app-development/interactive/form.html
+<%-
+# Specify admin groups by the full name of the group in the production HKey environment.
+adminGroups = [
+  "ondemand-admins-1025174" # HUIT OOD admin group, prod environment
+]
+# Specify course groups by Canvas course ID, which you can find in a url:
+# canvas.harvard.edu/courses/000000
+enabledGroups = [
+  # Cannot have multiple enabled groups if a spack installation in the course 
+  # shared folder is in use. This is because the course installation uses the 
+  # course shared folder, which is not accessible to users outside of that 
+  # course.
+  "161588"
+]
+
+def arrays_have_common_element(array1, array2)
+  # Use the `&` operator to get the intersection of the two arrays
+  # If the intersection is not empty, return true, otherwise false
+  !(array1 & array2).empty?
+end
+
+userGroups = OodSupport::User.new.groups.sort_by(&:id).map(&:name)
+# First check if the user is in an admin group
+if arrays_have_common_element(userGroups, adminGroups)
+  cluster="*"
+else
+  # If the user is not in an admin group, check if they're in an authorized Canvas group
+  userCanvasGroups = userGroups.flat_map{ |str| str.scan(/^canvas(\d+)-\d+/) }.flatten
+
+  # Check if the groups that the user is in match any of the courses that should
+  # have access to this app.
+
+  if arrays_have_common_element(userCanvasGroups, enabledGroups)
+    cluster="*"
+  else
+    cluster="disable_this_app"
+  end
+end
+-%>
+---
+title: Code Server - COMPSCI 2050 (GPU)
+cluster: "<%= cluster %>"
+cacheable: false
+
+# Form attributes that will be presented to the user and available to the 
+# scripts that launch the app. Think of this as initializing variables for use 
+# in the attributes section as needed.
+form:
+  - bc_num_hours
+  - bc_queue
+  - custom_num_gpus
+  - custom_spack_install
+  - custom_spack_environment
+
+# Customize how form variables appear to users. This is also where you can set 
+# a static value for a variable, in which case it will not be visible to users.
+attributes:
+  # How long will the job run for? Configure min, max, and step to set limits 
+  # on how long app sessions can run.
+  bc_num_hours:
+    value: 2
+    min: 1
+    max: 6  # 6 hours max
+    step: 1
+
+  # Which queue to submit to. Usually `general` is the best choice, unless this 
+  # app is configured for a specific EC2 instance type, like an instance type 
+  # with GPU resources.
+  bc_queue: "gpu"
+  custom_num_gpus:
+    widget: "number_field"
+    label: "Number of GPUs"
+    help: "Each GPU allocated also allocates 12 CPU cores and 48GB of memory"
+    value: 1
+    min: 1
+    max: 4
+    step: 1
+  custom_spack_install: "/shared/courseSharedFolders/161588outer/161588/spack"
+  custom_spack_environment: "cs2050-gpu"

--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -4,7 +4,7 @@
 if custom_num_gpus.blank?
   gpuArg = ""
   cpuArg = "- \"--cpus-per-task=#{custom_num_cores.blank? ? 1 : custom_num_cores.to_i}\""
-  memArg = "- \"--mem-per-cpu=4\""
+  memArg = "- \"--mem-per-cpu=2\""
 else
   gpuArg = "- \"--gpus-per-node=#{custom_num_gpus.to_i}\""
   cpuArg = "- \"--cpus-per-gpu=12\""

--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -1,7 +1,22 @@
 ---
+
+<%-
+if custom_num_gpus.blank?
+  gpuArg = ""
+  cpuArg = "- \"--cpus-per-task=#{custom_num_cores.blank? ? 1 : custom_num_cores.to_i}\""
+  memArg = "- \"--mem-per-cpu=4\""
+else
+  gpuArg = "- \"--gpus-per-node=#{custom_num_gpus.to_i}\""
+  cpuArg = "- \"--cpus-per-gpu=12\""
+  memArg = "- \"--mem-per-gpu=48\""
+end
+-%>
+
 batch_connect:
   template: "basic"
 script:
   native:
     - "--nodes=1"
-    - "--cpus-per-task=<%= custom_num_cores.blank? ? 1 : custom_num_cores.to_i %>"
+    <%= cpuArg.to_s %>
+    <%= memArg.to_s %>
+    <%= gpuArg.to_s %>

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -16,14 +16,16 @@ export PASSWORD="$password"
 log "Running on compute node ${SLURMD_NODENAME}:$port"
 
 # Activate the shared spack environment
-. /shared/spack/share/spack/setup-env.sh
+SPACK_INSTALL_ROOT=<%= context.respond_to?('custom_spack_install') ? context.custom_spack_install.to_s : "/shared/spack" %>
+. ${SPACK_INSTALL_ROOT}/share/spack/setup-env.sh
 log "Loaded spack"
 which spack
 
 # Use spack to load code-server
 spack unload --all
-spack env activate codeserver
-log "Activated spack environment"
+SPACK_ENVIRONMENT=<%= context.respond_to?('custom_spack_environment') ? context.custom_spack_environment.to_s : "codeserver" %>
+spack env activate $SPACK_ENVIRONMENT
+log "Activated spack environment: $SPACK_ENVIRONMENT"
 
 CPP_FILE="$HOME/.vscode/c_cpp_properties.json"
 


### PR DESCRIPTION
# Overview

This PR sets up two new Code Server app configs for CS 2050, one for a CPU-only app on the general queue, and another for the GPU queue. Both are configured to use Spack environments in the course shared folder, so that course staff can configure the software available to students directly.

# Changes

## Spack Environment

This PR alters the way that the `script.sh.erb` file starts the `code-server` from a Spack environment. It allows the form file under `local` for different sub-apps to specify a custom spack install location and/or a custom Spack environment name. To avoid having to change any existing sub-app configurations, each customization has a fallback specified in `template/script.sh.erb` to use the global Spack install location and the `codeserver` Spack environment by default.

## Slurm Job Resources

This PR also makes changes to how resources are allocated to Slurm jobs. The first goal for changing the resource allocation in `submit.yml.erb` was to allow for specifying GPU resources in the form files under `local` without requiring that non-gpu apps specify that they are not using GPU resources. I did that following the same pattern in place in [ood-jupyterlab-spack-conda](https://github.com/Harvard-ATG/ood-jupyterlab-spack-conda/blob/main/submit.yml.erb).

In addition to specifying GPU resources, the `submit.yml.erb` file also changes how CPU and memory resources are allocated to jobs. It's built on the assumption that a GPU app will only need to specify the number of GPUs, and a CPU-only app will only specify the number of CPUs (in addition to time, which we set for every app).

When GPU resources are specified, options for CPU and memory are specified according to an even distribution of the resources available in an [AWS G6 instance](https://aws.amazon.com/ec2/instance-types/g6/). The instances we run on have 4 GPUs, 48 CPUs, and 192GB of memory. To split those resources evenly, each GPU allocation also allocates 12 CPU and 48GB of RAM.

When CPU resources are specified, memory is allocated by the ratio in c5.12xlarge instances, which have 48 CPU cores and 96GB of RAM, so each CPU core also allocates 96GB of memory.

As an aside, in manually specified sbatch commands that one would use for research, one need not keep to the ratios on nodes, but rather allocate the resources that a particular compute job needs. Since this is a general purpose app config, I am keeping the resources split evenly based on what a user will specify to keep things simple. This is a choice that I'm making out of convenience in the absence of other pressures on what the app needs to do, not an iron-clad law of how you have to specify resources for Slurm jobs.

# Notes

## CPU Code Server Config

<details>
  <summary><code>diff -u local/generic.yml.erb local/cs2050-cpu.yml.erb</code></summary>

```diff
--- local/generic.yml.erb       2025-08-26 11:24:37
+++ local/cs2050-cpu.yml.erb    2026-01-12 10:32:58
@@ -18,7 +18,7 @@
   # shared folder is in use. This is because the course installation uses the 
   # course shared folder, which is not accessible to users outside of that 
   # course.
-  "135510"
+  "161588"
 ]
 
 def arrays_have_common_element(array1, array2)
@@ -46,7 +46,7 @@
 end
 -%>
 ---
-title: Code Server - Generic
+title: Code Server - COMPSCI 2050 (CPU)
 cluster: "<%= cluster %>"
 cacheable: false
 
@@ -57,6 +57,8 @@
   - bc_num_hours
   - bc_queue
   - custom_num_cores
+  - custom_spack_install
+  - custom_spack_environment
 
 # Customize how form variables appear to users. This is also where you can set 
 # a static value for a variable, in which case it will not be visible to users.
@@ -78,5 +80,7 @@
     label: "Number of CPUs"
     value: 1
     min: 1
-    max: 4
+    max: 48
     step: 1
+  custom_spack_install: "/shared/courseSharedFolders/161588outer/161588/spack"
+  custom_spack_environment: "cs2050-cpu"
```

</details>

## GPU Code Server Config

<details>
<summary><code>diff -u local/generic.yml.erb local/cs2050-gpu.yml.erb</code></summary>

```diff
--- local/generic.yml.erb       2025-08-26 11:24:37
+++ local/cs2050-gpu.yml.erb    2026-01-12 10:32:58
@@ -18,7 +18,7 @@
   # shared folder is in use. This is because the course installation uses the 
   # course shared folder, which is not accessible to users outside of that 
   # course.
-  "135510"
+  "161588"
 ]
 
 def arrays_have_common_element(array1, array2)
@@ -46,7 +46,7 @@
 end
 -%>
 ---
-title: Code Server - Generic
+title: Code Server - COMPSCI 2050 (GPU)
 cluster: "<%= cluster %>"
 cacheable: false
 
@@ -56,7 +56,9 @@
 form:
   - bc_num_hours
   - bc_queue
-  - custom_num_cores
+  - custom_num_gpus
+  - custom_spack_install
+  - custom_spack_environment
 
 # Customize how form variables appear to users. This is also where you can set 
 # a static value for a variable, in which case it will not be visible to users.
@@ -72,11 +74,14 @@
   # Which queue to submit to. Usually `general` is the best choice, unless this 
   # app is configured for a specific EC2 instance type, like an instance type 
   # with GPU resources.
-  bc_queue: "general"
-  custom_num_cores:
+  bc_queue: "gpu"
+  custom_num_gpus:
     widget: "number_field"
-    label: "Number of CPUs"
+    label: "Number of GPUs"
+    help: "Each GPU allocated also allocates 12 CPU cores and 48GB of memory"
     value: 1
     min: 1
     max: 4
     step: 1
+  custom_spack_install: "/shared/courseSharedFolders/161588outer/161588/spack"
+  custom_spack_environment: "cs2050-gpu"
```

</details>

## Using this diff pattern

I'm finding it helpful in reviewing my own work to diff my new local app config against the generic app config. Here's how I formatted the markdown for these diffs:

    <details>
    <summary><code>diff -u local/generic.yml.erb local/{modified file}</code></summary>
    
     ```diff
    {the diff}
    ```
    </details>

Running the `diff` command produces the output that I put in the code block, and marking the code block as a `diff` colors it appropriately. I plan to do this with future PRs, so I'm leaving breadcrumbs so I remember how.