### PR TITLE
COMPSCI 1411 Setup

### DIFF
--- a/local/cs1411-general.yml.erb
+++ b/local/cs1411-general.yml.erb
@@ -18,7 +18,7 @@ enabledGroups = [
   # shared folder is in use. This is because the course installation uses the 
   # course shared folder, which is not accessible to users outside of that 
   # course.
-  "135510"
+  "162593"
 ]
 
 def arrays_have_common_element(array1, array2)
@@ -75,7 +75,7 @@ attributes:
   # app is configured for a specific EC2 instance type, like an instance type 
   # with GPU resources.
   bc_queue: "general"
-  custom_num_cores: custom_num_cores:
+  custom_num_cores:
     widget: "number_field"
     label: "Number of CPUs"
     value: 1

--- a/local/cs1411-general.yml.erb
+++ b/local/cs1411-general.yml.erb
@@ -46,7 +46,7 @@ else
 end
 -%>
 ---
-title: Code Server - CS 1411 (metal)
+title: Code Server - CS 1411 (general)
 cluster: "<%= cluster %>"
 cacheable: false
 
@@ -68,13 +68,19 @@ attributes:
   bc_num_hours:
     value: 2
     min: 1
-    max: 2  # 2 hours max
+    max: 6  # 6 hours max
     step: 1
 
   # Which queue to submit to. Usually `general` is the best choice, unless this 
   # app is configured for a specific EC2 instance type, like an instance type 
   # with GPU resources.
-  bc_queue: "metal"
-  custom_num_cores: 96
+  bc_queue: "general"
+  custom_num_cores: custom_num_cores:
+    widget: "number_field"
+    label: "Number of CPUs"
+    value: 1
+    min: 1
+    max: 4
+    step: 1
   custom_spack_install: "/shared/courseSharedFolders/162593outer/162593/spack"
   custom_spack_environment: "cs1411"

--- a/local/cs1411-general.yml.erb
+++ b/local/cs1411-general.yml.erb
@@ -1,0 +1,80 @@
+# Code Server app user-facing configuration form file (generic sub-app)
+# This config file is both an actual configuration file for an actual sample 
+# application, and a starting point for configuring a new sub-app. To make a 
+# custom application launch for a course, make a copy of this file in the same
+# folder and customize the form config to your liking. There are notes along
+# the way to help you understand what options you can make configurable to users.
+# See the docs page from Open OnDemand for more details:
+# https://osc.github.io/ood-documentation/develop/how-tos/app-development/interactive/form.html
+<%-
+# Specify admin groups by the full name of the group in the production HKey environment.
+adminGroups = [
+  "ondemand-admins-1025174" # HUIT OOD admin group, prod environment
+]
+# Specify course groups by Canvas course ID, which you can find in a url:
+# canvas.harvard.edu/courses/000000
+enabledGroups = [
+  # Cannot have multiple enabled groups if a spack installation in the course 
+  # shared folder is in use. This is because the course installation uses the 
+  # course shared folder, which is not accessible to users outside of that 
+  # course.
+  "135510"
+]
+
+def arrays_have_common_element(array1, array2)
+  # Use the `&` operator to get the intersection of the two arrays
+  # If the intersection is not empty, return true, otherwise false
+  !(array1 & array2).empty?
+end
+
+userGroups = OodSupport::User.new.groups.sort_by(&:id).map(&:name)
+# First check if the user is in an admin group
+if arrays_have_common_element(userGroups, adminGroups)
+  cluster="*"
+else
+  # If the user is not in an admin group, check if they're in an authorized Canvas group
+  userCanvasGroups = userGroups.flat_map{ |str| str.scan(/^canvas(\d+)-\d+/) }.flatten
+
+  # Check if the groups that the user is in match any of the courses that should
+  # have access to this app.
+
+  if arrays_have_common_element(userCanvasGroups, enabledGroups)
+    cluster="*"
+  else
+    cluster="disable_this_app"
+  end
+end
+-%>
+---
+title: Code Server - CS 1411 (metal)
+cluster: "<%= cluster %>"
+cacheable: false
+
+# Form attributes that will be presented to the user and available to the 
+# scripts that launch the app. Think of this as initializing variables for use 
+# in the attributes section as needed.
+form:
+  - bc_num_hours
+  - bc_queue
+  - custom_num_cores
+  - custom_spack_install
+  - custom_spack_environment
+
+# Customize how form variables appear to users. This is also where you can set 
+# a static value for a variable, in which case it will not be visible to users.
+attributes:
+  # How long will the job run for? Configure min, max, and step to set limits 
+  # on how long app sessions can run.
+  bc_num_hours:
+    value: 2
+    min: 1
+    max: 2  # 2 hours max
+    step: 1
+
+  # Which queue to submit to. Usually `general` is the best choice, unless this 
+  # app is configured for a specific EC2 instance type, like an instance type 
+  # with GPU resources.
+  bc_queue: "metal"
+  custom_num_cores: 96
+  custom_spack_install: "/shared/courseSharedFolders/162593outer/162593/spack"
+  custom_spack_environment: "cs1411"

--- a/local/cs1411-metal.yml.erb
+++ b/local/cs1411-metal.yml.erb
@@ -57,6 +57,8 @@ form:
   - bc_num_hours
   - bc_queue
   - custom_num_cores
+  - custom_spack_install
+  - custom_spack_environment
 
 # Customize how form variables appear to users. This is also where you can set 
 # a static value for a variable, in which case it will not be visible to users.
@@ -66,17 +68,13 @@ attributes:
   bc_num_hours:
     value: 2
     min: 1
-    max: 6  # 6 hours max
+    max: 2  # 2 hours max
     step: 1
 
   # Which queue to submit to. Usually `general` is the best choice, unless this 
   # app is configured for a specific EC2 instance type, like an instance type 
   # with GPU resources.
-  bc_queue: "general"
-  custom_num_cores:
-    widget: "number_field"
-    label: "Number of CPUs"
-    value: 1
-    min: 1
-    max: 4
-    step: 1
+  bc_queue: "metal"
+  custom_num_cores: 96
+  custom_spack_install: "/shared/courseSharedFolders/162593outer/162593/spack"
+  custom_spack_environment: "cs1411"

--- a/local/cs1411-metal.yml.erb
+++ b/local/cs1411-metal.yml.erb
@@ -1,0 +1,82 @@
+# Code Server app user-facing configuration form file (generic sub-app)
+# This config file is both an actual configuration file for an actual sample 
+# application, and a starting point for configuring a new sub-app. To make a 
+# custom application launch for a course, make a copy of this file in the same
+# folder and customize the form config to your liking. There are notes along
+# the way to help you understand what options you can make configurable to users.
+# See the docs page from Open OnDemand for more details:
+# https://osc.github.io/ood-documentation/develop/how-tos/app-development/interactive/form.html
+<%-
+# Specify admin groups by the full name of the group in the production HKey environment.
+adminGroups = [
+  "ondemand-admins-1025174" # HUIT OOD admin group, prod environment
+]
+# Specify course groups by Canvas course ID, which you can find in a url:
+# canvas.harvard.edu/courses/000000
+enabledGroups = [
+  # Cannot have multiple enabled groups if a spack installation in the course 
+  # shared folder is in use. This is because the course installation uses the 
+  # course shared folder, which is not accessible to users outside of that 
+  # course.
+  "162593"
+]
+
+def arrays_have_common_element(array1, array2)
+  # Use the `&` operator to get the intersection of the two arrays
+  # If the intersection is not empty, return true, otherwise false
+  !(array1 & array2).empty?
+end
+
+userGroups = OodSupport::User.new.groups.sort_by(&:id).map(&:name)
+# First check if the user is in an admin group
+if arrays_have_common_element(userGroups, adminGroups)
+  cluster="*"
+else
+  # If the user is not in an admin group, check if they're in an authorized Canvas group
+  userCanvasGroups = userGroups.flat_map{ |str| str.scan(/^canvas(\d+)-\d+/) }.flatten
+
+  # Check if the groups that the user is in match any of the courses that should
+  # have access to this app.
+
+  if arrays_have_common_element(userCanvasGroups, enabledGroups)
+    cluster="*"
+  else
+    cluster="disable_this_app"
+  end
+end
+-%>
+---
+title: Code Server - CS 1411 (metal)
+cluster: "<%= cluster %>"
+cacheable: false
+
+# Form attributes that will be presented to the user and available to the 
+# scripts that launch the app. Think of this as initializing variables for use 
+# in the attributes section as needed.
+form:
+  - bc_num_hours
+  - bc_queue
+  - custom_num_cores
+
+# Customize how form variables appear to users. This is also where you can set 
+# a static value for a variable, in which case it will not be visible to users.
+attributes:
+  # How long will the job run for? Configure min, max, and step to set limits 
+  # on how long app sessions can run.
+  bc_num_hours:
+    value: 2
+    min: 1
+    max: 6  # 6 hours max
+    step: 1
+
+  # Which queue to submit to. Usually `general` is the best choice, unless this 
+  # app is configured for a specific EC2 instance type, like an instance type 
+  # with GPU resources.
+  bc_queue: "general"
+  custom_num_cores:
+    widget: "number_field"
+    label: "Number of CPUs"
+    value: 1
+    min: 1
+    max: 4
+    step: 1

--- a/spack-environment/cs1411/spack.yml
+++ b/spack-environment/cs1411/spack.yml
@@ -1,0 +1,23 @@
+# This is a Spack Environment file.
+#
+# It describes a set of packages to be installed, along with
+# configuration settings.
+spack:
+  # add package specs to the `specs` list
+  specs:
+  - likwid
+  - intel-pin
+  - code-server
+  view: true
+  concretizer:
+    unify: true
+  packages:
+    gcc:
+      externals:
+      - spec: gcc@11.5.0 languages:='c,c++,fortran'
+        prefix: /usr
+        extra_attributes:
+          compilers:
+            c: /usr/bin/gcc
+            cxx: /usr/bin/g++
+            fortran: /usr/bin/gfortran


### PR DESCRIPTION
# Overview

This is the course setup for CS 1411, formerly CS 146. This course is set up with a spack environment providing `code-server` as well as course software, served from a spack installation inside the course shared folder. This makes life easier for students (no need to activate a second environment inside the code server app), and allows course staff as well as developers from Academic Tech to add software during the semester. 

The course will need access to bare metal instances, so I set that up as a separate app, which uses the same software. The general queue and the metal queue both use c5 series EC2 instances, so there shouldn't be compatibility issues across the instance types.

# Changes

<details>
<summary><code>diff -u local/generic.yml.erb local/cs1411-general.yml.erb</code></summary>

 ```diff
--- local/generic.yml.erb       2025-08-26 11:24:37
+++ local/cs1411-general.yml.erb        2026-01-20 11:30:19
@@ -18,7 +18,7 @@
   # shared folder is in use. This is because the course installation uses the 
   # course shared folder, which is not accessible to users outside of that 
   # course.
-  "135510"
+  "162593"
 ]
 
 def arrays_have_common_element(array1, array2)
@@ -46,7 +46,7 @@
 end
 -%>
 ---
-title: Code Server - Generic
+title: Code Server - CS 1411 (general)
 cluster: "<%= cluster %>"
 cacheable: false
 
@@ -57,6 +57,8 @@
   - bc_num_hours
   - bc_queue
   - custom_num_cores
+  - custom_spack_install
+  - custom_spack_environment
 
 # Customize how form variables appear to users. This is also where you can set 
 # a static value for a variable, in which case it will not be visible to users.
@@ -80,3 +82,5 @@
     min: 1
     max: 4
     step: 1
+  custom_spack_install: "/shared/courseSharedFolders/162593outer/162593/spack"
+  custom_spack_environment: "cs1411"
```
</details>

<details>
<summary><code>diff -u local/generic.yml.erb local/cs1411-metal.yml.erb</code></summary>

 ```diff
--- local/generic.yml.erb       2025-08-26 11:24:37
+++ local/cs1411-metal.yml.erb  2026-01-20 11:23:23
@@ -18,7 +18,7 @@
   # shared folder is in use. This is because the course installation uses the 
   # course shared folder, which is not accessible to users outside of that 
   # course.
-  "135510"
+  "162593"
 ]
 
 def arrays_have_common_element(array1, array2)
@@ -46,7 +46,7 @@
 end
 -%>
 ---
-title: Code Server - Generic
+title: Code Server - CS 1411 (metal)
 cluster: "<%= cluster %>"
 cacheable: false
 
@@ -57,6 +57,8 @@
   - bc_num_hours
   - bc_queue
   - custom_num_cores
+  - custom_spack_install
+  - custom_spack_environment
 
 # Customize how form variables appear to users. This is also where you can set 
 # a static value for a variable, in which case it will not be visible to users.
@@ -66,17 +68,13 @@
   bc_num_hours:
     value: 2
     min: 1
-    max: 6  # 6 hours max
+    max: 2  # 2 hours max
     step: 1
 
   # Which queue to submit to. Usually `general` is the best choice, unless this 
   # app is configured for a specific EC2 instance type, like an instance type 
   # with GPU resources.
-  bc_queue: "general"
-  custom_num_cores:
-    widget: "number_field"
-    label: "Number of CPUs"
-    value: 1
-    min: 1
-    max: 4
-    step: 1
+  bc_queue: "metal"
+  custom_num_cores: 96
+  custom_spack_install: "/shared/courseSharedFolders/162593outer/162593/spack"
+  custom_spack_environment: "cs1411"
```
</details>
