### PR TITLE
add a global setup for code server

### DIFF
--- a/local/global.yml.erb
+++ b/local/global.yml.erb
@@ -1,0 +1,44 @@
+# Code Server app user-facing configuration form file (generic sub-app)
+# This config file is both an actual configuration file for an actual sample 
+# application, and a starting point for configuring a new sub-app. To make a 
+# custom application launch for a course, make a copy of this file in the same
+# folder and customize the form config to your liking. There are notes along
+# the way to help you understand what options you can make configurable to users.
+# See the docs page from Open OnDemand for more details:
+# https://osc.github.io/ood-documentation/develop/how-tos/app-development/interactive/form.html
+---
+title: Code Server - Universal
+description: This Code Server app has been configured for general use. If your course has a custom version of Code Server available, you should use that one instead.
+cluster: "*"
+cacheable: false
+
+# Form attributes that will be presented to the user and available to the 
+# scripts that launch the app. Think of this as initializing variables for use 
+# in the attributes section as needed.
+form:
+  - bc_num_hours
+  - bc_queue
+  - custom_num_cores
+
+# Customize how form variables appear to users. This is also where you can set 
+# a static value for a variable, in which case it will not be visible to users.
+attributes:
+  # How long will the job run for? Configure min, max, and step to set limits 
+  # on how long app sessions can run.
+  bc_num_hours:
+    value: 2
+    min: 1
+    max: 6  # 6 hours max
+    step: 1
+
+  # Which queue to submit to. Usually `general` is the best choice, unless this 
+  # app is configured for a specific EC2 instance type, like an instance type 
+  # with GPU resources.
+  bc_queue: "general"
+  custom_num_cores:
+    widget: "number_field"
+    label: "Number of CPUs"
+    value: 1
+    min: 1
+    max: 4
+    step: 1


### PR DESCRIPTION
# Overview

Add a setup for a Code Server app that's available to all users. It doesn't use anything special, in fact it's the same as the generic setup. I created a new config rather than using the generic one so that the generic config can continue to be a reference implementation that we use for more specific stuff.

To make it available to everyone, I've removed the group membership check and allowed it to run on any cluster.

<details>
<summary><code>diff -u local/generic.yml.erb local/global.yml.erb</code></summary>

 ```diff
--- local/generic.yml.erb       2025-08-26 11:24:37
+++ local/global.yml.erb        2026-02-05 15:33:40
@@ -6,48 +6,10 @@
 # the way to help you understand what options you can make configurable to users.
 # See the docs page from Open OnDemand for more details:
 # https://osc.github.io/ood-documentation/develop/how-tos/app-development/interactive/form.html
-<%-
-# Specify admin groups by the full name of the group in the production HKey environment.
-adminGroups = [
-  "ondemand-admins-1025174" # HUIT OOD admin group, prod environment
-]
-# Specify course groups by Canvas course ID, which you can find in a url:
-# canvas.harvard.edu/courses/000000
-enabledGroups = [
-  # Cannot have multiple enabled groups if a spack installation in the course 
-  # shared folder is in use. This is because the course installation uses the 
-  # course shared folder, which is not accessible to users outside of that 
-  # course.
-  "135510"
-]
-
-def arrays_have_common_element(array1, array2)
-  # Use the `&` operator to get the intersection of the two arrays
-  # If the intersection is not empty, return true, otherwise false
-  !(array1 & array2).empty?
-end
-
-userGroups = OodSupport::User.new.groups.sort_by(&:id).map(&:name)
-# First check if the user is in an admin group
-if arrays_have_common_element(userGroups, adminGroups)
-  cluster="*"
-else
-  # If the user is not in an admin group, check if they're in an authorized Canvas group
-  userCanvasGroups = userGroups.flat_map{ |str| str.scan(/^canvas(\d+)-\d+/) }.flatten
-
-  # Check if the groups that the user is in match any of the courses that should
-  # have access to this app.
-
-  if arrays_have_common_element(userCanvasGroups, enabledGroups)
-    cluster="*"
-  else
-    cluster="disable_this_app"
-  end
-end
--%>
 ---
-title: Code Server - Generic
-cluster: "<%= cluster %>"
+title: Code Server - Universal
+description: This Code Server app has been configured for general use. If your course has a custom version of Code Server available, you should use that one instead.
+cluster: "*"
 cacheable: false
 
 # Form attributes that will be presented to the user and available to the
```
</details>