### PR TITLE
Course/cs2650

### DIFF
--- a/local/cs2650-gpu.yml.erb
+++ b/local/cs2650-gpu.yml.erb
@@ -57,7 +57,6 @@ form:
   - bc_num_hours
   - bc_queue
   - custom_num_gpus
-  - custom_spack_install
   - custom_spack_environment
 
 # Customize how form variables appear to users. This is also where you can set 

--- a/local/cs2650-gpu.yml.erb
+++ b/local/cs2650-gpu.yml.erb
@@ -1,0 +1,79 @@
+# Code Server app user-facing configuration form file (generic sub-app)
+# This config file is both an actual configuration file for an actual sample 
+# application, and a starting point for configuring a new sub-app. To make a 
+# custom application launch for a course, make a copy of this file in the same
+# folder and customize the form config to your liking. There are notes along
+# the way to help you understand what options you can make configurable to users.
+# See the docs page from Open OnDemand for more details:
+# https://osc.github.io/ood-documentation/develop/how-tos/app-development/interactive/form.html
+<%-
+# Specify admin groups by the full name of the group in the production HKey environment.
+adminGroups = [
+  "ondemand-admins-1025174" # HUIT OOD admin group, prod environment
+]
+# Specify course groups by Canvas course ID, which you can find in a url:
+# canvas.harvard.edu/courses/000000
+enabledGroups = [
+  # Cannot have multiple enabled groups if a spack installation in the course 
+  # shared folder is in use. This is because the course installation uses the 
+  # course shared folder, which is not accessible to users outside of that 
+  # course.
+  "162794" # COMPSCI 2650: Big Data Systems - Spring 2026
+]
+
+def arrays_have_common_element(array1, array2)
+  # Use the `&` operator to get the intersection of the two arrays
+  # If the intersection is not empty, return true, otherwise false
+  !(array1 & array2).empty?
+end
+
+userGroups = OodSupport::User.new.groups.sort_by(&:id).map(&:name)
+# First check if the user is in an admin group
+if arrays_have_common_element(userGroups, adminGroups)
+  cluster="*"
+else
+  # If the user is not in an admin group, check if they're in an authorized Canvas group
+  userCanvasGroups = userGroups.flat_map{ |str| str.scan(/^canvas(\d+)-\d+/) }.flatten
+
+  # Check if the groups that the user is in match any of the courses that should
+  # have access to this app.
+
+  if arrays_have_common_element(userCanvasGroups, enabledGroups)
+    cluster="*"
+  else
+    cluster="disable_this_app"
+  end
+end
+-%>
+---
+title: Code Server - COMPSCI 2650 (GPU)
+cluster: "<%= cluster %>"
+cacheable: false
+
+# Form attributes that will be presented to the user and available to the 
+# scripts that launch the app. Think of this as initializing variables for use 
+# in the attributes section as needed.
+form:
+  - bc_num_hours
+  - bc_queue
+  - custom_num_gpus
+  - custom_spack_install
+  - custom_spack_environment
+
+# Customize how form variables appear to users. This is also where you can set 
+# a static value for a variable, in which case it will not be visible to users.
+attributes:
+  # How long will the job run for? Configure min, max, and step to set limits 
+  # on how long app sessions can run.
+  bc_num_hours:
+    value: 2
+    min: 1
+    max: 6  # 6 hours max
+    step: 1
+
+  # Which queue to submit to. Usually `general` is the best choice, unless this 
+  # app is configured for a specific EC2 instance type, like an instance type 
+  # with GPU resources.
+  bc_queue: "gpu"
+  custom_num_gpus: 1
+  custom_spack_environment: "cs2650-gpu"

--- a/spack-environment/cs2650-gpu/spack.yml
+++ b/spack-environment/cs2650-gpu/spack.yml
@@ -1,0 +1,14 @@
+# This is a Spack Environment file.
+#
+# It describes a set of packages to be installed, along with
+# configuration settings.
+spack:
+  # add package specs to the `specs` list
+  specs:
+  - code-server@4.96.4
+  - python
+  - python-venv
+  - py-pip
+  view: true
+  concretizer:
+    unify: true

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -27,6 +27,12 @@ SPACK_ENVIRONMENT=<%= context.respond_to?('custom_spack_environment') ? context.
 spack env activate $SPACK_ENVIRONMENT
 log "Activated spack environment: $SPACK_ENVIRONMENT"
 
+# If running on GPU... (determined by ruby code)
+if [[ <%= context.respond_to?('custom_num_gpus') ? "1" : "0" %> ]]; then
+  # Add ncu and nsys executable locations to PATH
+  PATH="/usr/local/cuda-12.8/nsight-systems-2024.6.2/bin:/usr/local/cuda-12.8/nsight-compute-2025.1.1:$PATH"
+fi
+
 CPP_FILE="$HOME/.vscode/c_cpp_properties.json"
 
 if [[ -f "$CPP_FILE" ]]; then

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -30,7 +30,7 @@ log "Activated spack environment: $SPACK_ENVIRONMENT"
 # If running on GPU... (determined by ruby code)
 if [[ <%= context.respond_to?('custom_num_gpus') ? "1" : "0" %> ]]; then
   # Add ncu and nsys executable locations to PATH
-  PATH="/usr/local/cuda-12.8/nsight-systems-2024.6.2/bin:/usr/local/cuda-12.8/nsight-compute-2025.1.1:$PATH"
+  PATH="/usr/local/cuda/bin:$PATH"
 fi
 
 CPP_FILE="$HOME/.vscode/c_cpp_properties.json"


### PR DESCRIPTION
# Overview

This PR adds a setup for COMPSCI 2650. The course will use GPUs and NVidia software in an interactive environment, so I've set up a code server app to run on the GPU partition with a single GPU available. The instructor didn't call out non-gpu access specifically, so there isn't a separate environment for CPU work. If needed, there's the globally available generic code server app.

The app setup can be tested in the stage environment after applying a local change to update the CPUs per GPU and memory per GPU for stage GPU nodes. In stage, the number of CPUs per GPU is 8, and the memory per GPU is 32. This change is made in the `submit.yml.erb` file.

# Changes

- Adds custom spack yml with environment for CS 2650. This includes Python, pip, and virtualenv in case they want that too.
- Adds NVidia software locations to PATH when launching the app. This will now happen for any Code Server that has `custom_num_gpus` set, which is how we set up apps to run on the GPU queue.
- 
<details>
<summary><code>diff -u local/generic.yml.erb local/cs2650-gpu.yml.erb</code></summary>

 ```diff
--- local/generic.yml.erb       2025-08-26 11:24:37
+++ local/cs2650-gpu.yml.erb    2026-03-10 15:48:37
@@ -18,7 +18,7 @@
   # shared folder is in use. This is because the course installation uses the 
   # course shared folder, which is not accessible to users outside of that 
   # course.
-  "135510"
+  "162794" # COMPSCI 2650: Big Data Systems - Spring 2026
 ]
 
 def arrays_have_common_element(array1, array2)
@@ -46,7 +46,7 @@
 end
 -%>
 ---
-title: Code Server - Generic
+title: Code Server - COMPSCI 2650 (GPU)
 cluster: "<%= cluster %>"
 cacheable: false
 
@@ -56,7 +56,8 @@
 form:
   - bc_num_hours
   - bc_queue
-  - custom_num_cores
+  - custom_num_gpus
+  - custom_spack_environment
 
 # Customize how form variables appear to users. This is also where you can set 
 # a static value for a variable, in which case it will not be visible to users.
@@ -72,11 +73,6 @@
   # Which queue to submit to. Usually `general` is the best choice, unless this 
   # app is configured for a specific EC2 instance type, like an instance type 
   # with GPU resources.
-  bc_queue: "general"
-  custom_num_cores:
-    widget: "number_field"
-    label: "Number of CPUs"
-    value: 1
-    min: 1
-    max: 4
-    step: 1
+  bc_queue: "gpu"
+  custom_num_gpus: 1
+  custom_spack_environment: "cs2650-gpu"
```
</details>

# Notes

I was able to find the NVidia software locations because those same locations caused a problem when they included an out of date openssl binary, so I was able to reference the script that we use to fix that to find out where the CUDA stuff was.

# References

- [OOD IAC PR #99](https://github.com/HUIT-Cloud-Architecture/hcdo-cto-ood-app/pull/99) - details on openssl vulnerability fix applied to NVidia software install location